### PR TITLE
Auto-generate PDF output

### DIFF
--- a/.github/workflows/update-gist.yaml
+++ b/.github/workflows/update-gist.yaml
@@ -3,34 +3,35 @@
 name: Validate and update Resume Github Gist
 
 on:
-    push:
-        branches:
-            - master
-            - feature/*
-        paths-ignore:
-            - 'README.md'
+  push:
+    branches:
+      - master
+      - feature/*
+    paths-ignore:
+      - "README.md"
 jobs:
-  validate-resume:
-    name: Validate resume complies with schema
+  validate-and-publish-resume:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Validate resume
-        run: resume validate
-  update-resume-gist:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: Devleaps/jsonresume-generator@v1.1.0
+        with:
+          action: "validate"
+      - name: Generate resume in PDF format
+        uses: Devleaps/jsonresume-generator@v1.1.0
+        with:
+          action: "render"
+          file: resume.json
+          output-type: "pdf"
+          theme-local: false
+          theme-name: jsonresume-theme-stackoverflow
+      - name: Upload PDF as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume
+          path: resume.pdf
       - name: Update Resume Gist
         uses: exuanbo/actions-deploy-gist@v1
         with:


### PR DESCRIPTION
## Summary by Sourcery

Streamline the resume CI workflow by using the jsonresume-generator action to validate the resume, produce a PDF, upload it as an artifact, and update the GitHub Gist in a single job.

New Features:
- Generate PDF version of the resume using jsonresume-generator
- Upload the generated PDF as a GitHub Action artifact

Enhancements:
- Consolidate validation and gist update into a single workflow job
- Replace manual Python setup and resume-cli commands with Devleaps/jsonresume-generator actions

CI:
- Update GitHub Actions workflow to validate, render, and deploy the resume in one job